### PR TITLE
refactor: type 6/8 message parsing

### DIFF
--- a/lib/ex_ais/data/ais.ex
+++ b/lib/ex_ais/data/ais.ex
@@ -5,7 +5,7 @@ defmodule ExAIS.Data.Ais do
 
   require Logger
 
-  alias ExAIS.Data.Decoders.WeatherReport
+  alias ExAIS.Data.Decoders
   alias ExAIS.Data.SixBit, as: SixBit
 
   @doc """
@@ -200,25 +200,29 @@ defmodule ExAIS.Data.Ais do
   # !AIVDM,1,1,,A,6>jCKIkfJjOt>db;q700@20,2*16
   defp parse_message(msg_type, payload) when msg_type == 6 do
     <<repeat_indicator::2, mmsi::30, sequence_number::2, destination_id::30, retransmit_flag::1,
-      spare::1, dac::10, fid::6, data::bitstring>> = payload
+      spare::1, dac::10, fi::6, data::bitstring>> = payload
 
     gla_map =
-      if fid == 10 do
-        ExAIS.Data.Decoders.Type6.Gla.from_binary(data)
-        |> Map.from_struct()
-      else
-        %{}
+      case fi == 10 do
+        true ->
+          Decoders.Type6.Gla.from_binary(data)
+          |> Map.from_struct()
+
+        _ ->
+          %{}
       end
 
     %{
-      repeat_indicator: repeat_indicator,
-      mmsi: mmsi,
-      sequence_number: sequence_number,
+      application_data: data,
+      application_identifier: "#{dac}#{fi}",
+      dac: dac,
       destination_id: destination_id,
+      fi: fi,
+      mmsi: mmsi,
+      repeat_indicator: repeat_indicator,
       retransmit_flag: retransmit_flag,
-      spare: spare,
-      application_identifier: "#{dac}#{fid}",
-      application_data: data
+      sequence_number: sequence_number,
+      spare: spare
     }
     |> Map.merge(gla_map)
   end
@@ -305,12 +309,12 @@ defmodule ExAIS.Data.Ais do
   # https://www.navcen.uscg.gov/?pageName=AISMessage8
   # !AIVDM,1,1,,A,83HT5APj2P00000001BQJ@2E0000,0*72
   defp parse_message(msg_type, payload) when msg_type == 8 do
-    <<repeat_indicator::2, mmsi::30, spare::2, dac::10, fid::6, data::bitstring>> =
+    <<repeat_indicator::2, mmsi::30, spare::2, dac::10, fi::6, data::bitstring>> =
       payload
 
     weather_map =
-      if fid == 31 do
-        WeatherReport.from_binary(data)
+      if fi == 31 do
+        Decoders.WeatherReport.from_binary(data)
         |> Map.from_struct()
       else
         %{}
@@ -320,7 +324,9 @@ defmodule ExAIS.Data.Ais do
       repeat_indicator: repeat_indicator,
       mmsi: mmsi,
       spare: spare,
-      application_identifier: "#{dac}#{fid}"
+      application_identifier: "#{dac}#{fi}",
+      dac: dac,
+      fi: fi
     }
     |> Map.merge(weather_map)
   end

--- a/lib/ex_ais/data/decoders/type6/gla.ex
+++ b/lib/ex_ais/data/decoders/type6/gla.ex
@@ -9,78 +9,26 @@ defmodule ExAIS.Data.Decoders.Type6.Gla do
      20–29   : analogue_external_2 (10)
      30–34   : status_internal (5)
      35–42   : status_external (8)
-     43      : off_position (1)
+     43      : off_position_indicator (1)
      44+     : spare bits
   """
 
-  import Bitwise
-
   defstruct [
     :analogue_internal,
-    :analogue_internal_v,
     :analogue_external_1,
-    :analogue_external_1_v,
     :analogue_external_2,
-    :analogue_external_2_v,
-    :status_internal_raw,
-    :status_external_raw,
-    :status_internal_decoded,
-    :status_external_decoded,
-    :off_position
+    :status_internal,
+    :status_external,
+    :off_position_indicator
   ]
-
-  @racon_map %{
-    0b00 => "racon_not_installed",
-    0b01 => "racon_not_monitored",
-    0b10 => "racon_operational",
-    0b11 => "racon_error"
-  }
-
-  @light_map %{
-    0b00 => "no_light_or_not_monitored",
-    0b01 => "light_on",
-    0b10 => "light_off",
-    0b11 => "light_error"
-  }
-
-  @doc """
-  Decode the 5-bit GLA AtoN status field.
-  bit4–3 → RACON (reversed order)
-  bit2–1 → Light (reversed order)
-  bit0   → Health
-  """
-
-  @spec decode_status(0..31) :: %{
-          racon_status: String.t(),
-          light_status: String.t(),
-          health: String.t(),
-          alarm?: boolean()
-        }
-  def decode_status(bits) when is_integer(bits) and bits in 0..31 do
-    racon_bits = bits >>> 3 &&& 0b11
-    light_bits = bits >>> 1 &&& 0b11
-    health_bit = bits &&& 0b1
-
-    %{
-      racon_status: Map.fetch!(@racon_map, racon_bits),
-      light_status: Map.fetch!(@light_map, light_bits),
-      health: if(health_bit == 0, do: "good", else: "alarm"),
-      alarm?: health_bit == 1
-    }
-  end
 
   @type t :: %__MODULE__{
           analogue_internal: non_neg_integer(),
-          analogue_internal_v: float(),
           analogue_external_1: non_neg_integer(),
-          analogue_external_1_v: float(),
           analogue_external_2: non_neg_integer(),
-          analogue_external_2_v: float(),
-          status_internal_raw: non_neg_integer(),
-          status_external_raw: non_neg_integer(),
-          status_internal_decoded: map(),
-          status_external_decoded: map(),
-          off_position: String.t()
+          status_internal: non_neg_integer(),
+          status_external: non_neg_integer(),
+          off_position_indicator: non_neg_integer()
         }
 
   @spec from_binary(bitstring()) :: t()
@@ -90,35 +38,16 @@ defmodule ExAIS.Data.Decoders.Type6.Gla do
         analogue_external_2::10,
         status_internal::5,
         status_external::8,
-        off_position::1,
+        off_position_indicator::1,
         _rest::bitstring
       >>) do
     %__MODULE__{
       analogue_internal: analogue_internal,
-      analogue_internal_v: to_voltage(analogue_internal),
       analogue_external_1: analogue_external_1,
-      analogue_external_1_v: to_voltage(analogue_external_1),
       analogue_external_2: analogue_external_2,
-      analogue_external_2_v: to_voltage(analogue_external_2),
-      status_internal_raw: status_internal,
-      status_external_raw: status_external,
-      status_internal_decoded: decode_status(status_internal),
-      status_external_decoded: decode_8bit_status(status_external),
-      off_position: decode_off_position(off_position)
+      status_internal: status_internal,
+      status_external: status_external,
+      off_position_indicator: off_position_indicator
     }
-  end
-
-  defp decode_8bit_status(bits) when is_integer(bits) and bits in 0..255 do
-    internal_part = bits &&& 0b00011111
-    spare = bits >>> 5
-    Map.merge(decode_status(internal_part), %{spare_flags: spare})
-  end
-
-  defp decode_off_position(0b0), do: "in_position"
-  defp decode_off_position(0b1), do: "off_position"
-
-  # Convert raw analogue value to voltage (0.05 V steps)
-  defp to_voltage(raw) when is_integer(raw) do
-    Float.round(raw * 0.05, 2)
   end
 end

--- a/test/ais_test.exs
+++ b/test/ais_test.exs
@@ -61,15 +61,10 @@ defmodule ExAIS.AisTest do
       assert attr.msg_type == 6
       assert attr.destination_id == 999_999_999
       assert attr.application_identifier == "23510"
+      assert attr.dac == 235
+      assert attr.fi == 10
 
-      assert is_number(attr.analogue_internal_v)
-
-      assert attr.status_internal_decoded.racon_status in [
-               "racon_not_installed",
-               "racon_not_monitored",
-               "racon_operational",
-               "racon_error"
-             ]
+      assert attr.analogue_internal == 559
     end
 
     test "decode class 7" do

--- a/test/decoders/type6/gla_test.exs
+++ b/test/decoders/type6/gla_test.exs
@@ -3,95 +3,6 @@ defmodule Decoders.Type6.GlaTest do
   use ExUnit.Case
 
   alias ExAIS.Data.Decoders.Type6.Gla
-  import Bitwise
-
-  describe "decode_status/1" do
-    test "decodes racon and light combinations correctly" do
-      # 0b10110 = racon_operational (10), light_off (10), health=0 (good)
-      result = Gla.decode_status(0b10100)
-
-      assert result.racon_status == "racon_operational"
-      assert result.light_status == "light_off"
-      assert result.health == "good"
-      refute result.alarm?
-    end
-  end
-
-  describe "racon_status decoding" do
-    test "00 → racon_not_installed" do
-      bits = 0b00 <<< 3
-      assert Gla.decode_status(bits).racon_status == "racon_not_installed"
-    end
-
-    test "01 → racon_not_monitored" do
-      bits = 0b01 <<< 3
-      assert Gla.decode_status(bits).racon_status == "racon_not_monitored"
-    end
-
-    test "10 → racon_operational" do
-      bits = 0b10 <<< 3
-      assert Gla.decode_status(bits).racon_status == "racon_operational"
-    end
-
-    test "11 → racon_error" do
-      bits = 0b11 <<< 3
-      assert Gla.decode_status(bits).racon_status == "racon_error"
-    end
-  end
-
-  describe "light_status decoding" do
-    test "00 → no_light_or_not_monitored" do
-      bits = 0b00 <<< 1
-      assert Gla.decode_status(bits).light_status == "no_light_or_not_monitored"
-    end
-
-    test "01 → light_on" do
-      bits = 0b01 <<< 1
-      assert Gla.decode_status(bits).light_status == "light_on"
-    end
-
-    test "10 → light_off" do
-      bits = 0b10 <<< 1
-      assert Gla.decode_status(bits).light_status == "light_off"
-    end
-
-    test "11 → light_error" do
-      bits = 0b11 <<< 1
-      assert Gla.decode_status(bits).light_status == "light_error"
-    end
-  end
-
-  describe "health decoding" do
-    test "0 → good" do
-      assert Gla.decode_status(0).health == "good"
-      refute Gla.decode_status(0).alarm?
-    end
-
-    test "1 → alarm" do
-      assert Gla.decode_status(1).health == "alarm"
-      assert Gla.decode_status(1).alarm?
-    end
-  end
-
-  describe "combined sanity checks" do
-    test "racon operational, light off, health good" do
-      bits = 0b10100
-      decoded = Gla.decode_status(bits)
-
-      assert decoded.racon_status == "racon_operational"
-      assert decoded.light_status == "light_off"
-      assert decoded.health == "good"
-    end
-
-    test "racon error, light on, alarm" do
-      bits = 0b11 <<< 3 ||| 0b10 <<< 1 ||| 0b1
-      decoded = Gla.decode_status(bits)
-
-      assert decoded.racon_status == "racon_error"
-      assert decoded.light_status == "light_off"
-      assert decoded.health == "alarm"
-    end
-  end
 
   describe "from_binary/1 analogue channels" do
     test "decodes analogue_internal and converts it to voltage" do
@@ -103,7 +14,6 @@ defmodule Decoders.Type6.GlaTest do
       msg = Gla.from_binary(payload)
 
       assert msg.analogue_internal == 512
-      assert msg.analogue_internal_v == 25.6
     end
 
     test "decodes analogue_external_1 and converts it to voltage" do
@@ -114,7 +24,6 @@ defmodule Decoders.Type6.GlaTest do
       msg = Gla.from_binary(payload)
 
       assert msg.analogue_external_1 == 600
-      assert msg.analogue_external_1_v == 30.0
     end
 
     test "decodes analogue_external_1 and converts it to zero voltage" do
@@ -125,7 +34,6 @@ defmodule Decoders.Type6.GlaTest do
       msg = Gla.from_binary(payload)
 
       assert msg.analogue_external_1 == 0
-      assert msg.analogue_external_1_v == 0.0
     end
 
     test "decodes analogue_external_2 and converts it to voltage" do
@@ -136,7 +44,6 @@ defmodule Decoders.Type6.GlaTest do
       msg = Gla.from_binary(payload)
 
       assert msg.analogue_external_2 == 720
-      assert msg.analogue_external_2_v == 36.0
     end
 
     test "decodes analogue_external_2 and converts it to zero voltage" do
@@ -147,7 +54,6 @@ defmodule Decoders.Type6.GlaTest do
       msg = Gla.from_binary(payload)
 
       assert msg.analogue_external_2 == 0
-      assert msg.analogue_external_2_v == 0.0
     end
 
     test "all three analogue channels populated together" do
@@ -160,33 +66,21 @@ defmodule Decoders.Type6.GlaTest do
       msg = Gla.from_binary(payload)
 
       assert msg.analogue_internal == 512
-      assert msg.analogue_internal_v == 25.6
 
       assert msg.analogue_external_1 == 600
-      assert msg.analogue_external_1_v == 30.0
 
       assert msg.analogue_external_2 == 720
-      assert msg.analogue_external_2_v == 36.0
     end
   end
 
   describe "from_binary/1 status fields & off_position" do
-    test "decodes status_internal into racon/light/health and preserves raw" do
-      # status_internal = 0b10110
-      #   racon bits (4–3): 10 -> racon_operational
-      #   light bits (2–1): 11 -> light_error
-      #   health bit (0):  0  -> good
+    test "decodes status_internal" do
       payload =
         <<0::10, 0::10, 0::10, 0b10110::5, 0b00000000::8, 0::1>>
 
       msg = Gla.from_binary(payload)
 
-      assert msg.status_internal_raw == 0b10110
-
-      assert msg.status_internal_decoded.racon_status == "racon_operational"
-      assert msg.status_internal_decoded.light_status == "light_error"
-      assert msg.status_internal_decoded.health == "good"
-      refute msg.status_internal_decoded.alarm?
+      assert msg.status_internal == 0b10110
     end
 
     test "decodes status_external 8-bit field into 5-bit status + spare_flags" do
@@ -198,23 +92,15 @@ defmodule Decoders.Type6.GlaTest do
 
       msg = Gla.from_binary(payload)
 
-      assert msg.status_external_raw == 0b10110110
-
-      assert msg.status_external_decoded.racon_status == "racon_operational"
-      assert msg.status_external_decoded.light_status == "light_error"
-      assert msg.status_external_decoded.health == "good"
-      refute msg.status_external_decoded.alarm?
-
-      # spare flags should be the top 3 bits of the external byte
-      assert msg.status_external_decoded.spare_flags == 0b101
+      assert msg.status_external == 0b10110110
     end
 
-    test "off_position bit 0 -> in_position" do
+    test "off_position bit 0 -> on_position" do
       payload =
         <<0::10, 0::10, 0::10, 0b00000::5, 0b00000000::8, 0::1>>
 
       msg = Gla.from_binary(payload)
-      assert msg.off_position == "in_position"
+      assert msg.off_position_indicator == 0
     end
 
     test "off_position bit 1 -> off_position" do
@@ -222,42 +108,7 @@ defmodule Decoders.Type6.GlaTest do
         <<0::10, 0::10, 0::10, 0b00000::5, 0b00000000::8, 1::1>>
 
       msg = Gla.from_binary(payload)
-      assert msg.off_position == "off_position"
-    end
-  end
-
-  describe "integration sanity check" do
-    test "decodes everything together in a realistic frame" do
-      # internal=512 (25.6V), ext1=600 (30.0V), ext2=720 (36.0V)
-      # status_internal=0b10110:
-      #   racon_operational, light_error, good
-      # status_external=0b10110110:
-      #   same 5b status + spare_flags = 0b101
-      # off_position=1
-      payload =
-        <<512::10, 600::10, 720::10, 0b10110::5, 0b10110110::8, 1::1>>
-
-      msg = Gla.from_binary(payload)
-
-      # voltages
-      assert msg.analogue_internal_v == 25.6
-      assert msg.analogue_external_1_v == 30.0
-      assert msg.analogue_external_2_v == 36.0
-
-      # internal status
-      assert msg.status_internal_decoded.racon_status == "racon_operational"
-      assert msg.status_internal_decoded.light_status == "light_error"
-      assert msg.status_internal_decoded.health == "good"
-      refute msg.status_internal_decoded.alarm?
-
-      # external status
-      assert msg.status_external_decoded.racon_status == "racon_operational"
-      assert msg.status_external_decoded.light_status == "light_error"
-      assert msg.status_external_decoded.health == "good"
-      assert msg.status_external_decoded.spare_flags == 0b101
-
-      # position status
-      assert msg.off_position == "off_position"
+      assert msg.off_position_indicator == 1
     end
   end
 end


### PR DESCRIPTION
Goal: simplyfy the type 6 message returns.

Refactors the parsing logic for Type 6 and Type 8 messages.

It reduces the the return in type 6 to bare minimums. This however does make the caller more reliant on understanding the bit masks to decode further. 

It replaces the magic numbers for `dac + fid` with `fi` to clarify the field usage. This also allows matching. Electrial type 6 has at lewast to differnt `fi` matches. There is also possibly a third in use that returns lat/lon data as it's own sub type.