### PR TITLE
feat: add Zeni decoding module and support for ANVDM

### DIFF
--- a/lib/ex_ais/data/ais.ex
+++ b/lib/ex_ais/data/ais.ex
@@ -202,13 +202,7 @@ defmodule ExAIS.Data.Ais do
     <<repeat_indicator::2, mmsi::30, sequence_number::2, destination_id::30, retransmit_flag::1,
       spare::1, dac::10, fid::6, data::bitstring>> = payload
 
-    gla_map =
-      if fid == 10 do
-        ExAIS.Data.Decoders.Type6.Gla.from_binary(data)
-        |> Map.from_struct()
-      else
-        %{}
-      end
+    application_data_map = ExAIS.Data.Decoders.Type6.decode(dac, fid, data)
 
     %{
       repeat_indicator: repeat_indicator,
@@ -220,7 +214,7 @@ defmodule ExAIS.Data.Ais do
       application_identifier: "#{dac}#{fid}",
       application_data: data
     }
-    |> Map.merge(gla_map)
+    |> Map.merge(application_data_map)
   end
 
   # AIS Binary Acknowledgment Message (Message 7)

--- a/lib/ex_ais/data/ais.ex
+++ b/lib/ex_ais/data/ais.ex
@@ -202,7 +202,7 @@ defmodule ExAIS.Data.Ais do
     <<repeat_indicator::2, mmsi::30, sequence_number::2, destination_id::30, retransmit_flag::1,
       spare::1, dac::10, fi::6, data::bitstring>> = payload
 
-    application_data_map = ExAIS.Data.Decoders.Type6.decode(dac, fid, data)
+    application_data_map = ExAIS.Data.Decoders.Type6.decode(dac, fi, data)
 
     %{
       application_data: data,

--- a/lib/ex_ais/data/decoders/type6.ex
+++ b/lib/ex_ais/data/decoders/type6.ex
@@ -1,0 +1,21 @@
+defmodule ExAIS.Data.Decoders.Type6 do
+  @moduledoc """
+  Dispatcher for AIS message type 6 sub-protocol decoders.
+
+  Routes to the appropriate decoder based on DAC + FI:
+
+    - FI 10     → GLA electrical/system status
+    - FI  0     → Zeni electrical/system status
+  """
+
+  alias ExAIS.Data.Decoders.Type6.Gla
+  alias ExAIS.Data.Decoders.Type6.Zeni
+
+  @gla_fid 10
+  @zeni_fid 0
+
+  @spec decode(non_neg_integer(), non_neg_integer(), bitstring()) :: map()
+  def decode(_dac, @gla_fid, data), do: Gla.from_binary(data) |> Map.from_struct()
+  def decode(_dac, @zeni_fid, data), do: Zeni.from_binary(data) |> Map.from_struct()
+  def decode(_dac, _fid, _data), do: %{}
+end

--- a/lib/ex_ais/data/decoders/type6/zeni.ex
+++ b/lib/ex_ais/data/decoders/type6/zeni.ex
@@ -1,0 +1,91 @@
+defmodule ExAIS.Data.Decoders.Type6.Zeni do
+  @moduledoc """
+  Decode a Zeni Type 6 (FI 9) Electrical / System Status payload.
+
+  Bit layout of the data portion (after DAC/FI):
+
+      0–15   : sub_application_id (16)
+     16–27   : voltage (12) — 0.1 V increments, max 409.6 V
+     28–37   : current (10) — 0.1 A increments, max 102.3 A
+     38      : power_supply_type (1) — 0: AC, 1: DC
+     39      : light_status (1)      — 0: Light Off, 1: Light On
+     40      : battery_status (1)    — 0: Good, 1: Low voltage
+     41      : off_position (1)      — 0: On position, 1: Off position
+     42–47   : spare (6)
+
+  Total: 48 bits (full Type 6 message occupies 136 bits / 1 slot).
+  """
+
+  defstruct [
+    :sub_application_id,
+    :voltage_raw,
+    :voltage_v,
+    :current_raw,
+    :current_a,
+    :power_supply_raw,
+    :power_supply,
+    :light_status_raw,
+    :light_status,
+    :battery_status_raw,
+    :battery_status,
+    :off_position_raw,
+    :off_position
+  ]
+
+  @type t :: %__MODULE__{
+          sub_application_id: non_neg_integer(),
+          voltage_raw: non_neg_integer(),
+          voltage_v: float(),
+          current_raw: non_neg_integer(),
+          current_a: float(),
+          power_supply_raw: 0 | 1,
+          power_supply: String.t(),
+          light_status_raw: boolean(),
+          light_status: String.t(),
+          battery_status_raw: boolean(),
+          battery_status: String.t(),
+          off_position_raw: boolean(),
+          off_position: String.t()
+        }
+
+  @spec from_binary(bitstring()) :: t()
+  def from_binary(<<
+        sub_application_id::16,
+        voltage::12,
+        current::10,
+        power_supply_bit::1,
+        light_status_bit::1,
+        battery_status_bit::1,
+        off_position_bit::1,
+        _spare::6,
+        _rest::bitstring
+      >>) do
+    %__MODULE__{
+      sub_application_id: sub_application_id,
+      voltage_raw: voltage,
+      voltage_v: Float.round(voltage * 0.1, 1),
+      current_raw: current,
+      current_a: Float.round(current * 0.1, 1),
+      power_supply_raw: power_supply_bit,
+      power_supply: decode_power_supply(power_supply_bit),
+      light_status_raw: light_status_bit == 1,
+      light_status: decode_light_status(light_status_bit),
+      battery_status_raw: battery_status_bit == 1,
+      battery_status: decode_battery_status(battery_status_bit),
+      off_position_raw: off_position_bit == 1,
+      off_position: decode_off_position(off_position_bit)
+    }
+  end
+
+  defp decode_power_supply(0), do: "ac"
+  defp decode_power_supply(1), do: "dc"
+
+  defp decode_light_status(0), do: "light_off"
+  defp decode_light_status(1), do: "light_on"
+
+  defp decode_battery_status(0), do: "good"
+  defp decode_battery_status(1), do: "low_voltage"
+
+  defp decode_off_position(0), do: "on_position"
+  defp decode_off_position(1), do: "off_position"
+end

--- a/lib/ex_ais/data/nmea.ex
+++ b/lib/ex_ais/data/nmea.ex
@@ -29,9 +29,9 @@ defmodule ExAIS.Data.NMEA do
     end
   end
 
-  # Decode !AIVDM and !BSVDM messages
+  # Decode !AIVDM, !BSVDM, and !ANVDM/!ANVDO messages (AIS / AtoN)
   defp decode(talker, formatter, values)
-       when (talker == "!AI" or talker == "!BS") and formatter in ["VDM", "VDO"] do
+       when talker in ["!AI", "!BS", "!AN"] and formatter in ["VDM", "VDO"] do
     keys = [
       :talker,
       :formatter,

--- a/test/decode_test.exs
+++ b/test/decode_test.exs
@@ -1,4 +1,5 @@
 defmodule ExAIS.DecodeTest do
+  @moduledoc false
   use ExUnit.Case
 
   import ExAIS.MessageFixtures

--- a/test/decoders/type6/zeni_test.exs
+++ b/test/decoders/type6/zeni_test.exs
@@ -1,0 +1,192 @@
+defmodule Decoders.Type6.ZeniTest do
+  @moduledoc false
+  use ExUnit.Case
+
+  alias ExAIS.Data
+  alias ExAIS.Data.Decoders.Type6.Zeni
+
+  describe "from_binary/1 – voltage field" do
+    test "decodes voltage raw value and converts to volts (0.1 V steps)" do
+      # voltage = 840 -> 84.0 V
+      payload = <<1::16, 840::12, 0::10, 0::1, 0::1, 0::1, 0::1, 0::6>>
+      msg = Zeni.from_binary(payload)
+
+      assert msg.voltage_raw == 840
+      assert msg.voltage_v == 84.0
+    end
+
+    test "zero voltage" do
+      payload = <<1::16, 0::12, 0::10, 0::1, 0::1, 0::1, 0::1, 0::6>>
+      msg = Zeni.from_binary(payload)
+
+      assert msg.voltage_raw == 0
+      assert msg.voltage_v == 0.0
+    end
+
+    test "maximum voltage value (4096 * 0.1 = 409.6 V)" do
+      payload = <<1::16, 4095::12, 0::10, 0::1, 0::1, 0::1, 0::1, 0::6>>
+      msg = Zeni.from_binary(payload)
+
+      assert msg.voltage_raw == 4095
+      assert msg.voltage_v == 409.5
+    end
+  end
+
+  describe "from_binary/1 – current field" do
+    test "decodes current raw value and converts to amps (0.1 A steps)" do
+      # current = 83 -> 8.3 A
+      payload = <<1::16, 0::12, 83::10, 0::1, 0::1, 0::1, 0::1, 0::6>>
+      msg = Zeni.from_binary(payload)
+
+      assert msg.current_raw == 83
+      assert msg.current_a == 8.3
+    end
+
+    test "zero current" do
+      payload = <<1::16, 0::12, 0::10, 0::1, 0::1, 0::1, 0::1, 0::6>>
+      msg = Zeni.from_binary(payload)
+
+      assert msg.current_raw == 0
+      assert msg.current_a == 0.0
+    end
+  end
+
+  describe "from_binary/1 – power supply type" do
+    test "0 -> raw 0, ac" do
+      payload = <<1::16, 0::12, 0::10, 0::1, 0::1, 0::1, 0::1, 0::6>>
+      msg = Zeni.from_binary(payload)
+      assert msg.power_supply_raw == 0
+      assert msg.power_supply == "ac"
+    end
+
+    test "1 -> raw 1, dc" do
+      payload = <<1::16, 0::12, 0::10, 1::1, 0::1, 0::1, 0::1, 0::6>>
+      msg = Zeni.from_binary(payload)
+      assert msg.power_supply_raw == 1
+      assert msg.power_supply == "dc"
+    end
+  end
+
+  describe "from_binary/1 – light status" do
+    test "0 -> raw false, light_off" do
+      payload = <<1::16, 0::12, 0::10, 0::1, 0::1, 0::1, 0::1, 0::6>>
+      msg = Zeni.from_binary(payload)
+      assert msg.light_status_raw == false
+      assert msg.light_status == "light_off"
+    end
+
+    test "1 -> raw true, light_on" do
+      payload = <<1::16, 0::12, 0::10, 0::1, 1::1, 0::1, 0::1, 0::6>>
+      msg = Zeni.from_binary(payload)
+      assert msg.light_status_raw == true
+      assert msg.light_status == "light_on"
+    end
+  end
+
+  describe "from_binary/1 – battery status" do
+    test "0 -> raw false, good" do
+      payload = <<1::16, 0::12, 0::10, 0::1, 0::1, 0::1, 0::1, 0::6>>
+      msg = Zeni.from_binary(payload)
+      assert msg.battery_status_raw == false
+      assert msg.battery_status == "good"
+    end
+
+    test "1 -> raw true, low_voltage" do
+      payload = <<1::16, 0::12, 0::10, 0::1, 0::1, 1::1, 0::1, 0::6>>
+      msg = Zeni.from_binary(payload)
+      assert msg.battery_status_raw == true
+      assert msg.battery_status == "low_voltage"
+    end
+  end
+
+  describe "from_binary/1 – off position status" do
+    test "0 -> raw false, on_position" do
+      payload = <<1::16, 0::12, 0::10, 0::1, 0::1, 0::1, 0::1, 0::6>>
+      msg = Zeni.from_binary(payload)
+      assert msg.off_position_raw == false
+      assert msg.off_position == "on_position"
+    end
+
+    test "1 -> raw true, off_position" do
+      payload = <<1::16, 0::12, 0::10, 0::1, 0::1, 0::1, 1::1, 0::6>>
+      msg = Zeni.from_binary(payload)
+      assert msg.off_position_raw == true
+      assert msg.off_position == "off_position"
+    end
+  end
+
+  describe "from_binary/1 – sub_application_id" do
+    test "preserves sub_application_id raw value" do
+      payload = <<42::16, 0::12, 0::10, 0::1, 0::1, 0::1, 0::1, 0::6>>
+      assert Zeni.from_binary(payload).sub_application_id == 42
+    end
+  end
+
+  describe "from_binary/1 – sample message integration" do
+    # Sample: !AIVDM,1,1,,B,6>h98`holKo<00000@Q@1h0,2*5D
+    # DAC=0 / FI=0, the data decodes to:
+    #   sub_application_id = 1
+    #   voltage = 133 -> 13.3 V
+    #   current = 1   -> 0.1 A
+    #   power_supply  = "dc"
+    #   light_status  = "light_on"
+    #   battery_status = "good"
+    #   off_position  = "on_position"
+    test "decodes all fields from the real Zeni sample payload" do
+      {:ok, sentence} =
+        Data.NMEA.parse("!AIVDM,1,1,,B,6>h98`holKo<00000@Q@1h0,2*5D")
+
+      {:ok, attr} = Data.Ais.parse(sentence.payload, sentence.padding)
+
+      assert attr.msg_type == 6
+      assert attr.application_identifier == "00"
+
+      assert attr.sub_application_id == 1
+
+      assert attr.voltage_raw == 133
+      assert attr.voltage_v == 13.3
+
+      assert attr.current_raw == 1
+      assert attr.current_a == 0.1
+
+      assert attr.power_supply_raw == 1
+      assert attr.power_supply == "dc"
+      assert attr.light_status_raw == true
+      assert attr.light_status == "light_on"
+      assert attr.battery_status_raw == false
+      assert attr.battery_status == "good"
+      assert attr.off_position_raw == false
+      assert attr.off_position == "on_position"
+    end
+  end
+
+  describe "from_binary/1 – Zeni Lite (DAC=0, FI=0) integration" do
+    # Payload: 6>h98`holKo<00000@QP0P0, padding 2
+    # Python decoder: sub_application_id=1, voltage_raw=134 (13.4V),
+    # current_raw=0 (0.0A), power_supply_raw=1 (DC),
+    # light_on=False, battery_low=False, off_position=False
+    test "decodes all fields from the Zeni Lite sample payload" do
+      {:ok, attr} = Data.Ais.parse("6>h98`holKo<00000@QP0P0", 2)
+
+      assert attr.msg_type == 6
+      assert attr.application_identifier == "00"
+
+      assert attr.sub_application_id == 1
+
+      assert attr.voltage_raw == 134
+      assert attr.voltage_v == 13.4
+
+      assert attr.current_raw == 0
+      assert attr.current_a == 0.0
+
+      assert attr.power_supply_raw == 1
+      assert attr.power_supply == "dc"
+      assert attr.light_status_raw == false
+      assert attr.light_status == "light_off"
+      assert attr.battery_status_raw == false
+      assert attr.battery_status == "good"
+      assert attr.off_position_raw == false
+      assert attr.off_position == "on_position"
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds support for decoding Zeni Type 6 (FI 0) AIS electrical/system status messages, generalizes the application data decoding for Type 6 messages, and improves test coverage for the new decoder. The changes introduce a dispatcher for Type 6 decoders, implement the Zeni decoder, and update the main AIS parser to use this new structure. Additionally, the NMEA parser is updated to recognize !ANVDM/!ANVDO messages, and comprehensive tests are added for the new Zeni decoder.

**Type 6 Application Data Decoding Improvements**
- Generalized the decoding of application data in Type 6 messages by introducing a dispatcher module (`ExAIS.Data.Decoders.Type6`) that routes based on DAC and FI, replacing the previous hardcoded logic for GLA only. (`lib/ex_ais/data/ais.ex`, `lib/ex_ais/data/decoders/type6.ex`) [[1]](diffhunk://#diff-3838e1b29753e9f25c19085550d6c3d6776c607a5350f7995ec011093f6dee75L205-R205) [[2]](diffhunk://#diff-3838e1b29753e9f25c19085550d6c3d6776c607a5350f7995ec011093f6dee75L223-R217) [[3]](diffhunk://#diff-d2837ff379977e07a7feee2cbf695c0f747b24df06f5490d2e6de95df76d318bR1-R21)
- Added a new decoder module for Zeni Type 6 (FI 0) electrical/system status messages, including field extraction and value conversion logic. (`lib/ex_ais/data/decoders/type6/zeni.ex`)

**NMEA Parsing Enhancements**
- Updated the NMEA parser to recognize and decode !ANVDM/!ANVDO sentences in addition to !AIVDM/!AIVDO and !BSVDM/!BSVDO. (`lib/ex_ais/data/nmea.ex`)

**Testing**
- Added comprehensive tests for the Zeni Type 6 decoder, covering all fields, edge cases, and integration with the main parser. (`test/decoders/type6/zeni_test.exs`)
- Minor: Added `@moduledoc false` to test modules for clarity. (`test/decode_test.exs`, `test/decoders/type6/zeni_test.exs`) [[1]](diffhunk://#diff-7a0d36a0a52240f35eb0a6ee9d7cfb5c125bf04e3f57231c24103a7a17cd62f6R2) [[2]](diffhunk://#diff-c32ef9b582979711c3021cdcfd51887f0b8adf566602a9b1ebc534fbceee79a2R1-R192)