### PR TITLE
feat: handle multi sentence nmea without g: tags

### DIFF
--- a/lib/ex_ais/ais_decoder.ex
+++ b/lib/ex_ais/ais_decoder.ex
@@ -137,10 +137,15 @@ defmodule ExAIS.Decoder do
   defp process_sentence_parts(parts, groups, latest, msg_types) do
     parts = normalize_parts(parts)
 
-    if group_message?(parts) do
-      handle_group_message(parts, groups, latest, msg_types)
-    else
-      handle_single_message(parts, groups, latest, msg_types)
+    cond do
+      group_message?(parts) ->
+        handle_group_message(parts, groups, latest, msg_types)
+
+      multi_sentence?(parts) ->
+        handle_multi_sentence(parts, groups, latest, msg_types)
+
+      true ->
+        handle_single_message(parts, groups, latest, msg_types)
     end
   end
 
@@ -154,6 +159,15 @@ defmodule ExAIS.Decoder do
 
   defp group_message?(parts) do
     Regex.match?(~r/,g:/, Enum.at(parts, 0))
+  end
+
+  defp multi_sentence?(parts) do
+    nmea = Enum.at(parts, 1, "")
+
+    case NMEA.parse(nmea) do
+      {:ok, %{total: total}} -> total != "1"
+      _ -> false
+    end
   end
 
   defp handle_group_message(parts, groups, latest, msg_types) do
@@ -171,6 +185,79 @@ defmodule ExAIS.Decoder do
     {decoded, %{groups: groups, latest: update_latest(latest, decoded)}}
   end
 
+  defp handle_multi_sentence([_, nmea_str] = parts, groups, latest, msg_types) do
+    with {:ok, parsed} <- NMEA.parse(nmea_str) do
+      %{
+        current: current,
+        channel: channel,
+        payload: payload,
+        sequential: sequential,
+        total: total
+      } = parsed
+
+      current_fragment = String.to_integer(current)
+      total_fragments = String.to_integer(total)
+
+      tags = decode_tags(Enum.at(parts, 0))
+
+      # Key by provider, channel and sequential id
+      provider = Map.get(tags, :s, "unknown")
+      group_key = "#{channel}-#{sequential}"
+
+      cond do
+        current_fragment == 1 ->
+          entry = %{tag: tags, payload: payload, time: DateTime.now!("Etc/UTC")}
+
+          new_groups = update_provider_group(groups, provider, group_key, entry)
+
+          {nil, %{groups: new_groups, latest: latest}}
+
+        current_fragment == total_fragments ->
+          provider_groups = Map.get(groups, provider, %{})
+
+          case provider_groups[group_key] do
+            nil ->
+              {nil, %{groups: groups, latest: latest}}
+
+            %{
+              tag: tag,
+              payload: existing_payload
+            } = _existing_entry ->
+              combined = existing_payload <> payload
+              new_groups = remove_provider_group(groups, provider, group_key)
+
+              synthetic_nmea = build_synthetic_nmea(parsed, combined)
+
+              case decode_nmea(synthetic_nmea, msg_types) do
+                {:ok, decoded} ->
+                  merged = Map.merge(tag, decoded)
+                  {merged, %{groups: new_groups, latest: update_latest(latest, merged)}}
+
+                _ ->
+                  {nil, %{groups: new_groups, latest: latest}}
+              end
+          end
+
+        true ->
+          provider_groups = Map.get(groups, provider, %{})
+
+          case provider_groups[group_key] do
+            nil ->
+              {nil, %{groups: groups, latest: latest}}
+
+            %{
+              payload: existing_payload
+            } = existing_entry ->
+              updated = %{existing_entry | payload: existing_payload <> payload}
+              new_groups = update_provider_group(groups, provider, group_key, updated)
+              {nil, %{groups: new_groups, latest: latest}}
+          end
+      end
+    else
+      _ -> {nil, %{groups: groups, latest: latest}}
+    end
+  end
+
   defp update_latest(latest, nil), do: latest
   defp update_latest(latest, %{timestamp: nil}), do: latest
 
@@ -183,6 +270,22 @@ defmodule ExAIS.Decoder do
     else
       latest
     end
+  end
+
+  defp build_synthetic_nmea(parsed, combined_payload) do
+    %{
+      channel: channel,
+      formatter: formatter,
+      padding: padding,
+      sequential: sequential,
+      talker: talker
+    } = parsed
+
+    body =
+      "#{talker}#{formatter},1,1,#{sequential},#{channel},#{combined_payload},#{padding}"
+
+    checksum = calc_checksum(String.slice(body, 1..-1//1))
+    "#{body}*#{checksum}"
   end
 
   def process_group(parts, groups, msg_types) do
@@ -277,7 +380,7 @@ defmodule ExAIS.Decoder do
     |> Enum.map(fn {provider, grps} ->
       new_grps =
         grps
-        |> Enum.filter(fn {_, v} -> DateTime.diff(now, v[:time]) > 30 end)
+        |> Enum.filter(fn {_, v} -> DateTime.diff(now, v[:time]) < 30 end)
         |> Enum.into(%{})
 
       {provider, new_grps}

--- a/lib/ex_ais/data/ais.ex
+++ b/lib/ex_ais/data/ais.ex
@@ -378,7 +378,7 @@ defmodule ExAIS.Data.Ais do
       spare::1, safety_related_text::bitstring>> = payload
 
     safety_text_size = Kernel.floor(bit_size(safety_related_text) / 6) * 6
-    <<safety_text::size(safety_text_size), _::bitstring>> = safety_related_text
+    <<safety_text::size(^safety_text_size), _::bitstring>> = safety_related_text
 
     %{
       repeat_indicator: repeat_indicator,
@@ -398,7 +398,7 @@ defmodule ExAIS.Data.Ais do
     <<repeat_indicator::2, mmsi::30, spare::2, safety_related_text::bitstring>> = payload
 
     safety_text_size = Kernel.floor(bit_size(safety_related_text) / 6) * 6
-    <<safety_text::size(safety_text_size), _::bitstring>> = safety_related_text
+    <<safety_text::size(^safety_text_size), _::bitstring>> = safety_related_text
 
     %{
       repeat_indicator: repeat_indicator,
@@ -563,8 +563,8 @@ defmodule ExAIS.Data.Ais do
       longitude::integer-signed-size(28), latitude::integer-signed-size(27), cog::12,
       true_heading::9, time_stamp::6, spare2::2, class_b_unit_flag::1, class_b_display_flag::1,
       class_b_dsc_flag::1, class_b_band_flag::1, class_b_message_22_flag::1, mode_flag::1,
-      raim_flag::1, communication_state_selector_flag::1, communication_state::19,
-      _::bitstring>> = payload
+      raim_flag::1, communication_state_selector_flag::1, communication_state::19, _::bitstring>> =
+      payload
 
     %{
       repeat_indicator: repeat_indicator,
@@ -743,7 +743,7 @@ defmodule ExAIS.Data.Ais do
     name_extension =
       if name_extension_size >= 6 and name_extension_size < 84 do
         rounded = Kernel.floor(name_extension_size / 6) * 6
-        <<name::size(rounded), _::bitstring>> = name_extension
+        <<name::size(^rounded), _::bitstring>> = name_extension
         SixBit.get_string(name, rounded)
       else
         ""
@@ -811,8 +811,8 @@ defmodule ExAIS.Data.Ais do
   # !AIVDM,1,1,,B,G02:Kn01R`sn@291nj600000900,2*12
   defp parse_message(msg_type, payload) when msg_type == 23 do
     <<repeat_indicator::2, user_id::30, spare1::2, ne_lon::18, ne_lat::17, sw_lon::18, sw_lat::17,
-      station_type::4, ship_type::8, spare2::22, tx_rx::2, interval::4, quiet::4,
-      _::bitstring>> = payload
+      station_type::4, ship_type::8, spare2::22, tx_rx::2, interval::4, quiet::4, _::bitstring>> =
+      payload
 
     %{
       repeat_indicator: repeat_indicator,
@@ -953,7 +953,7 @@ defmodule ExAIS.Data.Ais do
       end
 
     bin_size = bit_size(bindata) - 20
-    <<binary_datas::size(bin_size), radio_status::20>> = bindata
+    <<binary_datas::size(^bin_size), radio_status::20>> = bindata
     Map.merge(msg, %{binary_data: binary_datas, radio_status: radio_status})
   end
 

--- a/lib/ex_ais/data/ais.ex
+++ b/lib/ex_ais/data/ais.ex
@@ -563,8 +563,8 @@ defmodule ExAIS.Data.Ais do
       longitude::integer-signed-size(28), latitude::integer-signed-size(27), cog::12,
       true_heading::9, time_stamp::6, spare2::2, class_b_unit_flag::1, class_b_display_flag::1,
       class_b_dsc_flag::1, class_b_band_flag::1, class_b_message_22_flag::1, mode_flag::1,
-      raim_flag::1, communication_state_selector_flag::1, communication_state::19, _::bitstring>> =
-      payload
+      raim_flag::1, communication_state_selector_flag::1, communication_state::19,
+      _::bitstring>> = payload
 
     %{
       repeat_indicator: repeat_indicator,
@@ -811,8 +811,8 @@ defmodule ExAIS.Data.Ais do
   # !AIVDM,1,1,,B,G02:Kn01R`sn@291nj600000900,2*12
   defp parse_message(msg_type, payload) when msg_type == 23 do
     <<repeat_indicator::2, user_id::30, spare1::2, ne_lon::18, ne_lat::17, sw_lon::18, sw_lat::17,
-      station_type::4, ship_type::8, spare2::22, tx_rx::2, interval::4, quiet::4, _::bitstring>> =
-      payload
+      station_type::4, ship_type::8, spare2::22, tx_rx::2, interval::4, quiet::4,
+      _::bitstring>> = payload
 
     %{
       repeat_indicator: repeat_indicator,

--- a/lib/ex_ais/data/six_bit.ex
+++ b/lib/ex_ais/data/six_bit.ex
@@ -83,7 +83,7 @@ defmodule ExAIS.Data.SixBit do
   end
 
   defp do_chunks(binary, n, acc) do
-    <<chunk::size(n), rest::bitstring>> = binary
+    <<chunk::size(^n), rest::bitstring>> = binary
     do_chunks(rest, n, [<<chunk::size(n)>> | acc])
   end
 

--- a/test/decode_test.exs
+++ b/test/decode_test.exs
@@ -55,6 +55,55 @@ defmodule ExAIS.DecodeTest do
       assert latest == DateTime.from_unix!(1_694_649_009)
     end
 
+    test "station data" do
+      {decoded, _groups, latest} =
+        ExAIS.Decoder.decode_messages(
+          [
+            "\\s:poole,c:1782400298,t:LIVE*1A\\!AIVDM,1,1,,B,13IlvA01BrwnVHhLb5sAb1G:88G5,0*1E",
+            "\\s:poole,c:1782400298,t:LIVE*1A\\!AIVDM,1,1,,B,19NSsnP020wk;u0LPlnRkRE408G7,0*51",
+            "\\s:poole,c:1782400298,t:LIVE*1A\\!AIVDM,1,1,,A,13l3qvh020On6=nLm`5bG`C@0@G=,0*5A",
+            "\\s:poole,c:1782400298,t:LIVE*1A\\!AIVDM,1,1,,A,19NSnC@01VOm3vhLb679s7o<0HG@,0*78",
+            "\\s:poole,c:1782400298,t:LIVE*1A\\!AIVDM,1,1,,B,33MAleE000Onr32M12gcF;7@0Dmb,0*3C",
+            "\\s:poole,c:1782400299,t:LIVE*1B\\!AIVDM,1,1,,A,402=agAvadg;Wwpj8rLwAQ?02HGN,0*62"
+          ],
+          %{
+            fragment: "",
+            decoded: [],
+            groups: %{},
+            latest: DateTime.from_unix!(0)
+          },
+          Ais.all_msg_types()
+        )
+
+      assert Enum.count(decoded) == 6
+      assert latest == DateTime.from_unix!(1_782_400_299)
+    end
+
+    test "multi-sentence data without g: tags" do
+      {decoded, _groups, latest} =
+        ExAIS.Decoder.decode_messages(
+          [
+            "\\s:poole,c:1782400298,t:LIVE*1A\\!AIVDM,2,1,5,B,538ak0825hmSD8DsJ21<D50U0E:222222222220Q1R7BB5eT0@hiC52@p0kk,0*2D",
+            "\\s:poole,c:1782400298,t:LIVE*1A\\!AIVDM,2,2,5,B,SQ@m3l`8880,2*0A",
+            "\\s:poole,c:1782400299,t:LIVE*1B\\!AIVDM,2,1,6,B,56:0WB82>6Cl909J221PTr1LDV0P4V2222222217H96G95ec0LkS4U3H8888,0*23",
+            "\\s:poole,c:1782400299,t:LIVE*1B\\!AIVDM,2,2,6,B,88888888880,2*21",
+            "\\s:poole,c:1782400301,t:LIVE*1B\\!AIVDM,2,1,7,A,5815>I`2CDP=KL5WF20`4N11848QF2222222221@BhQ9G5e<0CkS0CDp8888,0*6A",
+            "\\s:poole,c:1782400301,t:LIVE*1B\\!AIVDM,2,2,7,A,88888888880,2*23",
+            "\\s:poole,c:1782400301,t:LIVE*1B\\!AIVDM,1,1,,B,91b544h70LwpTKnM0ghE0:P245pd,0*65"
+          ],
+          %{
+            fragment: "",
+            decoded: [],
+            groups: %{},
+            latest: DateTime.from_unix!(0)
+          },
+          Ais.all_msg_types()
+        )
+
+      assert Enum.count(decoded) == 4
+      assert latest == DateTime.from_unix!(1_782_400_301)
+    end
+
     test "group" do
       {_, %{groups: groups, latest: _latest}} =
         ExAIS.Decoder.decode_message(


### PR DESCRIPTION
### Features

Support added for multi-sentence nmea messages without `g:` tags.

### Fixes

- `prune_groups/1` - groups older than 30 seconds were retained and recent additions discarded
- pin operator warnings